### PR TITLE
changes to get macos prebuild to pass on arm64 local machine

### DIFF
--- a/.github/workflows/prebuild.yaml
+++ b/.github/workflows/prebuild.yaml
@@ -51,7 +51,7 @@ jobs:
           npm install nan
           . prebuild/macOS/preinstall.sh
           cp prebuild/macOS/binding.gyp binding.gyp
-          node-gyp rebuild -j 2 --arch=${{ runner.arch }}
+          node-gyp rebuild -j 2 --arch=${{ matrix.os.arch }}
           . prebuild/macOS/bundle.sh
 
       - name: Test binary

--- a/prebuild/macOS/binding.gyp
+++ b/prebuild/macOS/binding.gyp
@@ -23,7 +23,9 @@
       'defines': [
         'HAVE_GIF',
         'HAVE_JPEG',
-        'HAVE_RSVG'
+        'HAVE_RSVG',
+        'NAPI_DISABLE_CPP_EXCEPTIONS',
+        'NODE_ADDON_API_ENABLE_MAYBE'
       ],
       'libraries': [
         '<!@(pkg-config pixman-1 --libs)',
@@ -32,18 +34,22 @@
         '<!@(pkg-config pangocairo --libs)',
         '<!@(pkg-config freetype2 --libs)',
         '<!@(pkg-config librsvg-2.0 --libs)',
-        '-ljpeg',
+        '<!@(pkg-config libjpeg --libs)',
+        '-L/opt/homebrew/lib',
         '-lgif'
       ],
       'include_dirs': [
-        '<!(node -e "require(\'nan\')")',
+        '<!(node -p "require(\'node-addon-api\').include_dir")',
         '<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config libpng --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config pangocairo --cflags-only-I | sed s/-I//g)',
         '<!@(pkg-config freetype2 --cflags-only-I | sed s/-I//g)',
-        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)'
+        '<!@(pkg-config librsvg-2.0 --cflags-only-I | sed s/-I//g)',
+        '/opt/homebrew/include'
       ],
+      'cflags+': ['-fvisibility=hidden'],
       'xcode_settings': {
+        'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
       }
     }

--- a/prebuild/macOS/preinstall.sh
+++ b/prebuild/macOS/preinstall.sh
@@ -1,4 +1,4 @@
 brew update
-brew install pkg-config cairo pango librsvg python3 giflib # python3 is for macpack
+brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman python3 # python3 is for macpack
 brew upgrade python # activates python 3
 pip3 install --break-system-packages --user macpack


### PR DESCRIPTION
@jamesbvaughan these changes were necessary for me to build `build/Release/canvas.node` locally. They may get you past the current point of failure in your github action. I followed historical changes in [Readme.md](https://github.com/jamesbvaughan/node-canvas/commit/b0d4f44b5acf148b9b0a28f2354635a2eabc5b68) and the root [binding.gyp](https://github.com/jamesbvaughan/node-canvas/commit/ce29f697ced288b8d948e92b93b91d32ca3353d5#diff-0d6aa7470314ca774fd7e07f67b35ecd3045fe5cb3a0e5c99f48bae897905d32).
